### PR TITLE
Add support for external configuration of websocket host/port

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,2 @@
+websocketserver = 'broker.mqttdashboard.com';
+websocketport = 8000;

--- a/index.html
+++ b/index.html
@@ -302,6 +302,7 @@ limitations under the License.
 <script src="js/mqttws31.js"></script>
 <script src="js/encoder.js"></script>
 <script src="js/app.js"></script>
+<script src="config.js"></script>
 
 <script>
 
@@ -316,6 +317,8 @@ limitations under the License.
     $(document).foundation();
     $(document).ready(function () {
 
+        $('#urlInput').val(websocketserver);
+        $('#portInput').val(websocketport);
         $('#clientIdInput').val('clientId-' + randomString(10));
 
         $('#colorChooser').minicolors();


### PR DESCRIPTION
This small patch adds the possibility to 'configure' the Web client to obtain the MQTT hostname/port number from an included `config.js` file. This makes it easier to configure these values 'externally'.
